### PR TITLE
feat: Add date/time picker to relapse logging dialog

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,262 @@
+# Date/Time Selection for Relapse Logging — Spec
+
+## Context
+
+Currently, when a user logs a relapse, `occurredAt` is always set to `Clock.System.now()` — the exact moment they tap Submit. There's no way to log a relapse that happened earlier (e.g., last night, yesterday). This is unrealistic since users often don't open the app immediately after a relapse. This spec adds a date/time picker step to the `RelapseConfirmationDialog` so users can specify when the relapse actually occurred.
+
+## Overview
+
+- **Flow**: 3-step dialog: CONFIRMATION → DATE_TIME → REASON_INPUT
+- **Default**: Pre-fills with current date/time ("now"), user can change or skip
+- **Picker**: Material3 `DatePickerDialog` + `TimePickerDialog` (sequential)
+- **Constraints**: No future dates allowed, no past limit
+- **Precision**: Date + hour + minute (no seconds)
+- **Streak**: Calculated from the chosen date, not from "now"
+- **Time format**: Respects user's `TIME_FORMAT_24H` DataStore setting
+- **Scope**: New relapse logging only — existing relapses are not editable
+
+## Dialog Flow
+
+```
+Step 1 — CONFIRMATION (unchanged)
+  "Are you sure?"
+  [Confirm Relapse] → Step 2  |  [I'm still going] → dismiss
+
+Step 2 — DATE_TIME (new)
+  "When did this happen?"
+  Tappable row: 📅 icon + formatted date/time + ✏️ edit icon
+  Default: current date/time
+  Tap → DatePickerDialog → TimePickerDialog (sequential)
+  [Next] → Step 3  |  [Back] → Step 1
+
+Step 3 — REASON_INPUT (unchanged)
+  "Tell us more (Optional)"
+  Text field + [Submit] / [Skip]
+```
+
+## UI Implementation
+
+### Step 2 Composable
+
+New composable inside `RelapseConfirmationDialog.kt` (or extracted to a sibling file):
+
+```
+Column {
+    // Back arrow + "When did this happen?" title (same pattern as Step 3)
+
+    // Tappable date/time row
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { showDatePicker = true }
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(Icons.Default.CalendarMonth, tint = theme.iconPrimary)
+        Spacer(Modifier.width(12.dp))
+        Text(formattedDateTime, style = bodyLarge, modifier = Modifier.weight(1f))
+        Icon(Icons.Default.Edit, tint = theme.textSecondary)
+    }
+
+    // Next + Back buttons (same layout as other steps)
+}
+```
+
+### Material3 Date Picker
+
+```kotlin
+if (showDatePicker) {
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = selectedInstant.toEpochMilliseconds(),
+        selectableDates = object : SelectableDates {
+            // Disable future dates
+            override fun isSelectableDate(utcTimeMillis: Long) = utcTimeMillis <= nowMillis
+            override fun isSelectableYear(year: Int) = year <= currentYear
+        }
+    )
+    DatePickerDialog(
+        onDismissRequest = { showDatePicker = false },
+        confirmButton = {
+            TextButton(onClick = {
+                // Extract selected date, open time picker
+                showDatePicker = false
+                showTimePicker = true
+            }) { Text("OK") }
+        },
+        dismissButton = {
+            TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}
+```
+
+### Material3 Time Picker
+
+```kotlin
+if (showTimePicker) {
+    val timePickerState = rememberTimePickerState(
+        initialHour = selectedHour,
+        initialMinute = selectedMinute,
+        is24Hour = use24HourFormat  // From SettingsDataStore
+    )
+    // Use AlertDialog wrapper since Material3 doesn't have TimePickerDialog
+    AlertDialog(
+        onDismissRequest = { showTimePicker = false },
+        confirmButton = {
+            TextButton(onClick = {
+                // Combine date + time into new Instant
+                showTimePicker = false
+            }) { Text("OK") }
+        },
+        dismissButton = {
+            TextButton(onClick = { showTimePicker = false }) { Text("Cancel") }
+        },
+        text = { TimePicker(state = timePickerState) }
+    )
+}
+```
+
+### Date/Time Combination
+
+After both pickers confirm, combine the selected date and time into a single `Instant`:
+
+```kotlin
+val selectedInstant = LocalDateTime(
+    year, month, dayOfMonth, hour, minute
+).toInstant(TimeZone.currentSystemDefault())
+```
+
+Store as `selectedInstant` in ViewModel state. Format for display using existing `DateUtils.formatDate(use24Hour)`.
+
+## ViewModel Changes
+
+### DashboardViewModel.kt
+
+Add state for the selected date/time:
+
+```kotlin
+var selectedRelapseTime: Instant by mutableStateOf(Clock.System.now())
+    private set
+
+fun updateSelectedRelapseTime(instant: Instant) {
+    selectedRelapseTime = instant
+}
+```
+
+Update `submitRelapse()` to use `selectedRelapseTime` instead of `Clock.System.now()`:
+
+```kotlin
+fun submitRelapse() {
+    viewModelScope.launch {
+        val occurredAt = selectedRelapseTime  // Changed from Clock.System.now()
+        val streak = (occurredAt - lastRelapseTime).inWholeDays.toInt()
+            .coerceAtLeast(0)  // Calculate streak from chosen date
+        withContext(Dispatchers.IO) {
+            repository.logRelapse(
+                occurredAt.toString(),
+                streak = streak,
+                note = relapseReason.ifBlank { null }
+            )
+        }
+        dismissDialog()
+    }
+}
+```
+
+Update `showConfirmationDialog()` to reset `selectedRelapseTime` to `Clock.System.now()`.
+
+Update `dismissDialog()` to also reset `selectedRelapseTime`.
+
+### RelapseDialogStep enum
+
+```kotlin
+enum class RelapseDialogStep {
+    CONFIRMATION,
+    DATE_TIME,      // New
+    REASON_INPUT
+}
+```
+
+### New ViewModel methods
+
+```kotlin
+fun moveToDateTimeStep() { currentDialogStep = RelapseDialogStep.DATE_TIME }
+fun moveToReasonStep() { currentDialogStep = RelapseDialogStep.REASON_INPUT }
+fun moveBackToDateTime() { currentDialogStep = RelapseDialogStep.DATE_TIME }
+```
+
+## Streak Calculation Change
+
+The streak calculation in `submitRelapse()` currently uses `uiState.value.currentStreak` (the live counter). With this change, the streak must be recalculated based on the chosen `selectedRelapseTime`:
+
+```kotlin
+// Get the previous relapse time
+val lastRelapseTime = repository.lastRelapseTimeFlow().first()
+
+// Calculate streak: days between previous relapse and chosen time
+val streak = if (lastRelapseTime != null) {
+    (selectedRelapseTime - lastRelapseTime).inWholeDays.toInt().coerceAtLeast(0)
+} else {
+    0
+}
+```
+
+This ensures the streak stored on the *previous* relapse record accurately reflects the gap between the two relapses, even if the user picks a past date.
+
+## Dialog Wiring
+
+### DashboardScreen.kt
+
+Update the `DashboardRoute` composable to pass new props:
+
+```kotlin
+DashboardScreen(
+    // ... existing props ...
+    selectedRelapseTime = viewModel.selectedRelapseTime,
+    onDateTimeChange = { viewModel.updateSelectedRelapseTime(it) },
+    onNavigateToDateTime = { viewModel.moveToDateTimeStep() },
+    onBackToDateTime = { viewModel.moveBackToDateTime() },
+    timeFormat24H = use24HourFormat,  // from SettingsDataStore
+)
+```
+
+### RelapseConfirmationDialog
+
+Update the dialog to handle the new step. The `onConfirmRelapse` callback now navigates to DATE_TIME instead of REASON_INPUT. Add the date/time display row and picker dialogs for the DATE_TIME step.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `DashboardViewModel.kt` | Add `selectedRelapseTime` state, update `submitRelapse()` to use it, add step navigation methods, recalculate streak from chosen date |
+| `RelapseConfirmationDialog.kt` | Add DATE_TIME step with tappable date/time row, DatePickerDialog, TimePickerDialog |
+| `DashboardScreen.kt` | Wire new props (selectedRelapseTime, onDateTimeChange, timeFormat24H) through to dialog |
+| `DashboardState.kt` | (Optional) Could add `selectedRelapseTime` here instead of ViewModel directly |
+
+## Files NOT Modified
+
+- Entity/DAO/Repository — no schema or query changes. `occurredAt` is already a string, accepts any ISO 8601 value.
+- DateUtils — existing `formatDate()` already handles the display format needed.
+- Navigation — no new screens or routes.
+
+## Key Design Decisions
+
+1. **No future dates** — `SelectableDates` on `DatePickerState` disables future dates. Prevents illogical entries.
+2. **No past limit** — Users can log relapses from any past date. Streak is calculated from the chosen date.
+3. **Sequential pickers** — Date first, then time. Matches the mental model ("when" = date first, then time of day).
+4. **Streak from chosen date** — `(selectedRelapseTime - previousRelapseTime).inWholeDays` instead of the live counter. Ensures accurate streak bookkeeping.
+5. **Defaults to now** — `selectedRelapseTime` initializes to `Clock.System.now()`. User can submit without touching the picker.
+6. **24h format** — Uses `SettingsDataStore.timeFormat24HFlow` to set `TimePickerState.is24Hour`.
+
+## Verification
+
+1. **Default flow**: Open dialog → Confirm → see current date/time displayed → Next → reason → Submit. Relapse logged with current timestamp.
+2. **Custom date**: Tap the date row → DatePicker opens → select yesterday → TimePicker opens → pick 11:30 PM → Next → Submit. Relapse has yesterday's timestamp.
+3. **No future dates**: DatePicker should grey out/disable today+future dates.
+4. **Streak recalculation**: If previous relapse was 5 days ago and user picks a date 3 days ago, the streak on the previous relapse should be 3, not 5.
+5. **24h format**: If user has 24h enabled, TimePicker shows 24h. If disabled, shows 12h with AM/PM.
+6. **Back navigation**: From DATE_TIME step, back arrow goes to CONFIRMATION. From REASON_INPUT, back goes to DATE_TIME.
+7. **Display format**: Date/time row shows formatted like "01 May 2026 at 14:30" (or "01 May 2026 at 02:30 PM" in 12h mode).
+8. **Build**: `./gradlew assembleDebug` passes.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,4 +103,7 @@ dependencies {
 
     // Lottie
     implementation(libs.lottie.compose)
+
+    // Material Icon
+    implementation(libs.material.icons.extended)
 }

--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/dashboard/DashboardScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import dev.notsatria.stop_pmo.ui.components.CenterTopBar
 import dev.notsatria.stop_pmo.ui.components.EmptyStateView
 import dev.notsatria.stop_pmo.ui.components.HistoryItem
@@ -46,12 +46,15 @@ import dev.notsatria.stop_pmo.utils.DummyData
 import dev.notsatria.stop_pmo.utils.getBottomNavHeight
 import dev.notsatria.stop_pmo.utils.toHHmmss
 import org.koin.androidx.compose.koinViewModel
+import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Composable
 fun DashboardRoute(modifier: Modifier = Modifier, viewModel: DashboardViewModel = koinViewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val use24HourFormat by viewModel.use24HourFormat.collectAsStateWithLifecycle(false)
 
     DashboardScreen(
         modifier = modifier,
@@ -62,15 +65,23 @@ fun DashboardRoute(modifier: Modifier = Modifier, viewModel: DashboardViewModel 
         showConfirmationDialog = viewModel.showConfirmationDialog,
         currentDialogStep = viewModel.currentDialogStep,
         relapseReason = viewModel.relapseReason,
+        selectedRelapseTime = viewModel.selectedRelapseTime,
+        use24HourFormat = use24HourFormat,
         onDismissDialog = { viewModel.dismissDialog() },
-        onConfirmRelapse = { viewModel.moveToReasonStep() },
+        onConfirmRelapse = { viewModel.moveToDateTimeStep() },
+        onNextToReason = { viewModel.moveToReasonStep() },
         onReasonChange = { viewModel.updateRelapseReason(it) },
         onBackToConfirmation = { viewModel.moveBackToConfirmation() },
-        onSubmitRelapse = { viewModel.submitRelapse() }
+        onBackToDateTime = { viewModel.moveToDateTimeStep() },
+        onSubmitRelapse = { viewModel.submitRelapse() },
+        onDateTimeChange = { viewModel.updateSelectedRelapseTime(it) }
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(
+    ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class,
+    ExperimentalTime::class
+)
 @Composable
 fun DashboardScreen(
     modifier: Modifier = Modifier,
@@ -79,11 +90,16 @@ fun DashboardScreen(
     showConfirmationDialog: Boolean = false,
     currentDialogStep: RelapseDialogStep = RelapseDialogStep.CONFIRMATION,
     relapseReason: String = "",
+    selectedRelapseTime: kotlin.time.Instant = Clock.System.now(),
+    use24HourFormat: Boolean = true,
     onDismissDialog: () -> Unit = {},
     onConfirmRelapse: () -> Unit = {},
+    onNextToReason: () -> Unit = {},
     onReasonChange: (String) -> Unit = {},
     onBackToConfirmation: () -> Unit = {},
+    onBackToDateTime: () -> Unit = {},
     onSubmitRelapse: () -> Unit = {},
+    onDateTimeChange: (kotlin.time.Instant) -> Unit = {},
     theme: CustomTheme = LocalTheme.current,
 ) {
     Scaffold(modifier, topBar = {
@@ -148,12 +164,17 @@ fun DashboardScreen(
             RelapseConfirmationDialog(
                 currentStep = currentDialogStep,
                 relapseReason = relapseReason,
+                selectedRelapseTime = selectedRelapseTime,
+                use24HourFormat = use24HourFormat,
                 onDismiss = onDismissDialog,
                 onConfirmRelapse = onConfirmRelapse,
+                onNextToReason = onNextToReason,
                 onStillGoing = onDismissDialog,
                 onBackToConfirmation = onBackToConfirmation,
+                onBackToDateTime = onBackToDateTime,
                 onReasonChange = onReasonChange,
-                onSubmitRelapse = onSubmitRelapse
+                onSubmitRelapse = onSubmitRelapse,
+                onDateTimeChange = onDateTimeChange
             )
         }
     }
@@ -203,6 +224,7 @@ private fun DayCounter(modifier: Modifier = Modifier, duration: Duration) {
     }
 }
 
+@OptIn(ExperimentalTime::class)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PreviewDark() {
@@ -211,6 +233,7 @@ private fun PreviewDark() {
     }
 }
 
+@OptIn(ExperimentalTime::class)
 @Preview
 @Composable
 private fun EmptyPreview() {

--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/dashboard/DashboardViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dev.notsatria.stop_pmo.data.preference.SettingsDataStore
 import dev.notsatria.stop_pmo.domain.model.RelapseEvent
 import dev.notsatria.stop_pmo.domain.repository.RelapseRepository
 import dev.notsatria.stop_pmo.utils.getCurrentStreak
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -33,13 +35,16 @@ import kotlin.time.Instant
 
 enum class RelapseDialogStep {
     CONFIRMATION,
+    DATE_TIME,
     REASON_INPUT
 }
 
 @OptIn(ExperimentalTime::class)
-class DashboardViewModel(val repository: RelapseRepository) : ViewModel() {
+class DashboardViewModel(val repository: RelapseRepository, val settingDataStore: SettingsDataStore) : ViewModel() {
     private var _uiState = MutableStateFlow(DashboardState())
     val uiState: StateFlow<DashboardState> = _uiState.asStateFlow()
+
+    val use24HourFormat = settingDataStore.timeFormat24HFlow
 
     var showConfirmationDialog: Boolean by mutableStateOf(false)
         private set
@@ -50,38 +55,66 @@ class DashboardViewModel(val repository: RelapseRepository) : ViewModel() {
     var relapseReason: String by mutableStateOf("")
         private set
 
+    @OptIn(ExperimentalTime::class)
+    var selectedRelapseTime: Instant by mutableStateOf(Clock.System.now())
+        private set
+
+    @OptIn(ExperimentalTime::class)
     fun showConfirmationDialog() {
         showConfirmationDialog = true
         currentDialogStep = RelapseDialogStep.CONFIRMATION
         relapseReason = ""
+        selectedRelapseTime = Clock.System.now()
     }
 
+    @OptIn(ExperimentalTime::class)
     fun dismissDialog() {
         showConfirmationDialog = false
         currentDialogStep = RelapseDialogStep.CONFIRMATION
         relapseReason = ""
+        selectedRelapseTime = Clock.System.now()
     }
 
     fun moveToReasonStep() {
         currentDialogStep = RelapseDialogStep.REASON_INPUT
     }
 
+    fun moveToDateTimeStep() {
+        currentDialogStep = RelapseDialogStep.DATE_TIME
+    }
+
     fun moveBackToConfirmation() {
         currentDialogStep = RelapseDialogStep.CONFIRMATION
+    }
+
+    fun moveBackToDateTime() {
+        currentDialogStep = RelapseDialogStep.DATE_TIME
     }
 
     fun updateRelapseReason(reason: String) {
         relapseReason = reason
     }
 
+    @OptIn(ExperimentalTime::class)
+    fun updateSelectedRelapseTime(instant: Instant) {
+        selectedRelapseTime = instant
+    }
+
+    @OptIn(ExperimentalTime::class)
     fun submitRelapse() {
         viewModelScope.launch {
-            val now = Clock.System.now()
-            d("Logging relapse at $now with reason: $relapseReason")
+            val occurredAt = selectedRelapseTime
+            d("Logging relapse at $occurredAt with reason: $relapseReason")
             withContext(Dispatchers.IO) {
+                val lastRelapseTime = repository.lastRelapseTimeFlow().first()
+                val streak = if (lastRelapseTime != null) {
+                    (occurredAt - lastRelapseTime).inWholeDays.toInt().coerceAtLeast(0)
+                } else {
+                    0
+                }
                 repository.logRelapse(
-                    now.toString(), 
-                    streak = uiState.value.currentStreak, 
+                    occurredAt.toString(),
+                    streak = streak,
                     note = relapseReason.ifBlank { null }
                 )
             }

--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/dashboard/components/RelapseConfirmationDialog.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/dashboard/components/RelapseConfirmationDialog.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,21 +18,36 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -44,19 +60,31 @@ import androidx.compose.ui.unit.sp
 import dev.notsatria.stop_pmo.R
 import dev.notsatria.stop_pmo.ui.screen.dashboard.RelapseDialogStep
 import dev.notsatria.stop_pmo.ui.theme.LocalTheme
+import dev.notsatria.stop_pmo.utils.formatDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import java.util.Date
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Composable
 fun RelapseConfirmationDialog(
     modifier: Modifier = Modifier,
     currentStep: RelapseDialogStep,
     relapseReason: String,
+    selectedRelapseTime: Instant,
+    use24HourFormat: Boolean,
     onDismiss: () -> Unit,
     onConfirmRelapse: () -> Unit,
     onStillGoing: () -> Unit,
+    onNextToReason: () -> Unit,
     onBackToConfirmation: () -> Unit,
+    onBackToDateTime: () -> Unit,
     onReasonChange: (String) -> Unit,
     onSubmitRelapse: () -> Unit,
+    onDateTimeChange: (Instant) -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 ) {
     val theme = LocalTheme.current
@@ -70,7 +98,8 @@ fun RelapseConfirmationDialog(
         AnimatedContent(
             targetState = currentStep,
             transitionSpec = {
-                if (targetState == RelapseDialogStep.REASON_INPUT) {
+                val forward = targetState.ordinal > initialState.ordinal
+                if (forward) {
                     slideInHorizontally(
                         initialOffsetX = { fullWidth -> fullWidth },
                         animationSpec = tween(300, easing = LinearEasing)
@@ -96,16 +125,205 @@ fun RelapseConfirmationDialog(
                     onConfirmRelapse = onConfirmRelapse,
                     onStillGoing = onStillGoing
                 )
+
+                RelapseDialogStep.DATE_TIME -> DateTimeContent(
+                    modifier = modifier,
+                    selectedTime = selectedRelapseTime,
+                    use24HourFormat = use24HourFormat,
+                    onBack = onBackToConfirmation,
+                    onNext = onNextToReason,
+                    onDateTimeChange = onDateTimeChange
+                )
+
                 RelapseDialogStep.REASON_INPUT -> ReasonInputContent(
                     modifier = modifier,
                     relapseReason = relapseReason,
                     onReasonChange = onReasonChange,
-                    onBack = onBackToConfirmation,
+                    onBack = onBackToDateTime,
                     onSubmit = onSubmitRelapse,
                     onSkip = onSubmitRelapse
                 )
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
+@Composable
+private fun DateTimeContent(
+    modifier: Modifier = Modifier,
+    selectedTime: Instant,
+    use24HourFormat: Boolean,
+    onBack: () -> Unit,
+    onNext: () -> Unit,
+    onDateTimeChange: (Instant) -> Unit
+) {
+    val theme = LocalTheme.current
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
+    val timeZone = TimeZone.currentSystemDefault()
+    val localDateTime = selectedTime.toLocalDateTime(timeZone)
+
+    val formattedDateTime = selectedTime.toEpochMilliseconds().let { millis ->
+        val date = Date(millis)
+        date.formatDate(use24HourFormat)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 32.dp)
+            .padding(bottom = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_left),
+                    contentDescription = "Back",
+                    tint = theme.textPrimary
+                )
+            }
+            Text(
+                text = "When did this happen?",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                color = theme.textPrimary,
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Text(
+            text = "Select the date and time of the relapse. Defaults to now if unchanged.",
+            fontSize = 14.sp,
+            color = theme.textSecondary,
+            textAlign = TextAlign.Start,
+            lineHeight = 20.sp,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = theme.surface,
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .clickable { showDatePicker = true }
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.CalendarMonth,
+                contentDescription = null,
+                tint = theme.iconPrimary,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = formattedDateTime,
+                fontSize = 16.sp,
+                color = theme.textPrimary,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = Icons.Default.Edit,
+                contentDescription = "Change date/time",
+                tint = theme.textSecondary,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = onNext,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = theme.buttonPrimary
+            )
+        ) {
+            Text(
+                text = "Next",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+    }
+
+    if (showDatePicker) {
+        val nowMillis = System.currentTimeMillis()
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedTime.toEpochMilliseconds(),
+            selectableDates = object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long) = utcTimeMillis <= nowMillis
+                override fun isSelectableYear(year: Int) =
+                    year <= java.util.Calendar.getInstance().get(java.util.Calendar.YEAR)
+            }
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val selectedMillis = datePickerState.selectedDateMillis
+                    if (selectedMillis != null) {
+                        val selectedDate = Date(selectedMillis)
+                        val cal = java.util.Calendar.getInstance().apply {
+                            time = selectedDate
+                            set(java.util.Calendar.HOUR_OF_DAY, localDateTime.hour)
+                            set(java.util.Calendar.MINUTE, localDateTime.minute)
+                            set(java.util.Calendar.SECOND, 0)
+                            set(java.util.Calendar.MILLISECOND, 0)
+                        }
+                        val newInstant = Instant.fromEpochMilliseconds(cal.timeInMillis)
+                        onDateTimeChange(newInstant)
+                    }
+                    showDatePicker = false
+                    showTimePicker = true
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    if (showTimePicker) {
+        val timePickerState = rememberTimePickerState(
+            initialHour = localDateTime.hour,
+            initialMinute = localDateTime.minute,
+            is24Hour = use24HourFormat
+        )
+        AlertDialog(
+            onDismissRequest = { showTimePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val cal = java.util.Calendar.getInstance().apply {
+                        timeInMillis = selectedTime.toEpochMilliseconds()
+                        set(java.util.Calendar.HOUR_OF_DAY, timePickerState.hour)
+                        set(java.util.Calendar.MINUTE, timePickerState.minute)
+                        set(java.util.Calendar.SECOND, 0)
+                        set(java.util.Calendar.MILLISECOND, 0)
+                    }
+                    val newInstant = Instant.fromEpochMilliseconds(cal.timeInMillis)
+                    onDateTimeChange(newInstant)
+                    showTimePicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTimePicker = false }) { Text("Cancel") }
+            },
+            text = { TimePicker(state = timePickerState) }
+        )
     }
 }
 
@@ -311,34 +529,44 @@ private fun ReasonInputContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Preview
 @Composable
 private fun PreviewConfirmation() {
     RelapseConfirmationDialog(
         currentStep = RelapseDialogStep.CONFIRMATION,
         relapseReason = "",
+        selectedRelapseTime = Clock.System.now(),
+        use24HourFormat = true,
         onDismiss = {},
         onConfirmRelapse = {},
         onStillGoing = {},
         onBackToConfirmation = {},
+        onBackToDateTime = {},
         onReasonChange = {},
-        onSubmitRelapse = {}
+        onSubmitRelapse = {},
+        onDateTimeChange = {},
+        onNextToReason = {}
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class)
 @Preview
 @Composable
 private fun PreviewReasonInput() {
     RelapseConfirmationDialog(
         currentStep = RelapseDialogStep.REASON_INPUT,
         relapseReason = "",
+        selectedRelapseTime = Clock.System.now(),
+        use24HourFormat = true,
         onDismiss = {},
         onConfirmRelapse = {},
         onStillGoing = {},
         onBackToConfirmation = {},
+        onBackToDateTime = {},
         onReasonChange = {},
-        onSubmitRelapse = {}
+        onSubmitRelapse = {},
+        onDateTimeChange = {},
+        onNextToReason = {}
     )
 }

--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/history/HistoryScreen.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/history/HistoryScreen.kt
@@ -28,6 +28,7 @@ import dev.notsatria.stop_pmo.ui.components.HistoryItem
 import dev.notsatria.stop_pmo.ui.components.HistoryItemType
 import dev.notsatria.stop_pmo.ui.theme.LocalTheme
 import dev.notsatria.stop_pmo.utils.DummyData
+import dev.notsatria.stop_pmo.utils.getBottomNavHeight
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.koin.androidx.compose.koinViewModel
 
@@ -117,6 +118,10 @@ fun HistoryScreen(
                         isButtonRelapseVisible = true
                     )
                 }
+            }
+
+            item {
+                Spacer(Modifier.height(getBottomNavHeight() + 60.dp))
             }
         }
     }

--- a/app/src/main/java/dev/notsatria/stop_pmo/utils/DateUtils.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/utils/DateUtils.kt
@@ -57,6 +57,22 @@ val dateFormat1 = SimpleDateFormat("dd MMM", Locale.ENGLISH)
 val timeFormat24H = SimpleDateFormat("HH:mm", Locale.ENGLISH)
 val timeFormat12H = SimpleDateFormat("hh:mm a", Locale.ENGLISH)
 
+fun Date.formatDate(use24Hour: Boolean): String {
+    try {
+        val result = buildString {
+            append(defaultDateFormat.format(this@formatDate))
+            append(" ")
+            append("at")
+            append(" ")
+            if (use24Hour) append(timeFormat24H.format(this@formatDate))
+            else append(timeFormat12H.format(this@formatDate))
+        }
+        return result
+    } catch (_: Exception) {
+        return ""
+    }
+}
+
 @OptIn(ExperimentalTime::class)
 fun String.formatDate(use24Hour: Boolean): String {
     try {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2025.08.00"
 logger = "2.2.0"
+materialIconsExtended = "1.7.3"
 mockk = "1.14.6"
 room = "2.7.2"
 devtoolsKsp = "2.2.10-2.0.2"
@@ -43,6 +44,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 logger = { module = "com.orhanobut:logger", version.ref = "logger" }
+material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 room = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 roomCompiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
Adds a DATE_TIME step to the RelapseConfirmationDialog between CONFIRMATION and REASON_INPUT, allowing users to select when the relapse actually occurred instead of always using "now".

- Add DATE_TIME step to RelapseDialogStep enum
- Add Material3 DatePickerDialog + TimePickerDialog (sequential)
- Pre-fill with current time, no future dates allowed
- Recalculate streak from chosen date instead of live counter
- Respect user's 24h/12h time format setting
- Add SPEC.md with full design specification