### PR TITLE
feat: add heatmap and date filter to analytics

### DIFF
--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/analytics/AnalyticsScreen.kt
@@ -3,30 +3,42 @@ package dev.notsatria.stop_pmo.ui.screen.analytics
 import androidx.compose.animation.core.EaseInOutCubic
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,12 +48,18 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import dev.notsatria.stop_pmo.R
 import dev.notsatria.stop_pmo.ui.components.CenterTopBar
 import dev.notsatria.stop_pmo.ui.theme.CustomTheme
 import dev.notsatria.stop_pmo.ui.theme.LocalTheme
 import dev.notsatria.stop_pmo.utils.DummyData
+import dev.notsatria.stop_pmo.utils.dateFormat2
+import dev.notsatria.stop_pmo.utils.formatDate
 import dev.notsatria.stop_pmo.utils.formatDateOnly
+import dev.notsatria.stop_pmo.utils.getBottomNavHeight
 import ir.ehsannarmani.compose_charts.LineChart
 import ir.ehsannarmani.compose_charts.models.AnimationMode
 import ir.ehsannarmani.compose_charts.models.DotProperties
@@ -50,7 +68,33 @@ import ir.ehsannarmani.compose_charts.models.HorizontalIndicatorProperties
 import ir.ehsannarmani.compose_charts.models.LabelHelperProperties
 import ir.ehsannarmani.compose_charts.models.LabelProperties
 import ir.ehsannarmani.compose_charts.models.Line
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
 import org.koin.androidx.compose.koinViewModel
+import kotlin.time.ExperimentalTime
+
+private val HeatmapGreen1 = Color(0xFFBBF7D0)
+private val HeatmapGreen2 = Color(0xFF86EFAC)
+private val HeatmapGreen3 = Color(0xFF4ADE80)
+private val HeatmapGreen4 = Color(0xFF22C55E)
+private val HeatmapGreen5 = Color(0xFF166534)
+private val HeatmapRelapse = Color(0xFFDC2626)
+private val HeatmapRelapseBorder = Color(0xFFFCA5A5)
+
+private fun heatmapColor(streakDays: Int, isRelapse: Boolean, dividerColor: Color): Color {
+    if (isRelapse) return HeatmapRelapse
+    return when {
+        streakDays == 0 -> dividerColor
+        streakDays <= 7 -> HeatmapGreen1
+        streakDays <= 14 -> HeatmapGreen2
+        streakDays <= 30 -> HeatmapGreen3
+        streakDays <= 60 -> HeatmapGreen4
+        else -> HeatmapGreen5
+    }
+}
 
 @Composable
 fun AnalyticsRoute(
@@ -60,7 +104,8 @@ fun AnalyticsRoute(
     val uiState by viewModel.uiState.collectAsState()
 
     AnalyticsScreen(
-        uiState = uiState
+        uiState = uiState,
+        onFilterSelected = viewModel::onFilterSelected
     )
 }
 
@@ -68,6 +113,7 @@ fun AnalyticsRoute(
 @Composable
 fun AnalyticsScreen(
     uiState: AnalyticsState = AnalyticsState(),
+    onFilterSelected: (DateFilter) -> Unit = {},
     theme: CustomTheme = LocalTheme.current
 ) {
     Scaffold(
@@ -76,19 +122,37 @@ fun AnalyticsScreen(
         },
         containerColor = theme.surface
     ) { paddingValues ->
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .padding(16.dp),
         ) {
             if (uiState.isLoading) {
-                LoadingIndicator()
-            } else if (uiState.chartData.isEmpty()) {
-                EmptyStateMessage()
+                item {
+                    LoadingIndicator()
+                }
+            } else if (uiState.chartData.isEmpty() && uiState.heatmapData.isEmpty()) {
+                item {
+                    EmptyStateMessage()
+                }
             } else {
-                Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                item {
                     StreakSummaryCard(streakData = uiState.streakData)
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+                item {
+                    HeatmapCard(heatmapData = uiState.heatmapData)
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+                item {
+                    DateFilterChips(
+                        selectedFilter = uiState.selectedFilter,
+                        onFilterSelected = onFilterSelected
+                    )
+                }
+                item { Spacer(Modifier.height(16.dp)) }
+                item {
                     RelapseChart(
                         chartData = uiState.chartData,
                         modifier = Modifier
@@ -96,6 +160,7 @@ fun AnalyticsScreen(
                             .height(400.dp)
                     )
                 }
+                item { Spacer(Modifier.height(getBottomNavHeight() + 60.dp)) }
             }
         }
     }
@@ -161,6 +226,287 @@ private fun EmptyStateMessage() {
     }
 }
 
+@OptIn(ExperimentalTime::class)
+@Composable
+private fun HeatmapCard(heatmapData: List<HeatmapDay>) {
+    val theme = LocalTheme.current
+    val today = remember {
+        kotlin.time.Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    }
+
+    val monthLabels = remember(heatmapData) {
+        if (heatmapData.isEmpty()) return@remember emptyList()
+        val startDate = heatmapData.first().date
+        val labels = mutableListOf<Pair<Int, String>>()
+        var currentMonth = startDate.month
+        for ((index, day) in heatmapData.withIndex()) {
+            if (day.date.month != currentMonth) {
+                val weekCol = index / 7
+                labels.add(weekCol to day.date.month.name.take(3))
+                currentMonth = day.date.month
+            }
+        }
+        labels
+    }
+
+    val heatmapWidth = remember(heatmapData) {
+        val weeks = (heatmapData.size + 6) / 7
+        weeks * 16
+    }
+
+    val scrollState = rememberScrollState(initial = Int.MAX_VALUE)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        border = BorderStroke(width = 2.dp, brush = SolidColor(theme.divider)),
+        colors = CardDefaults.cardColors(containerColor = theme.cardContainer)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Activity",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = theme.textPrimary
+                )
+                HeatmapLegend()
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row {
+                Column(
+                    modifier = Modifier.padding(end = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Spacer(modifier = Modifier.height(14.dp))
+                    for (label in listOf("M", "", "W", "", "F", "", "")) {
+                        Text(
+                            text = label,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = theme.textSecondary,
+                            fontSize = 8.sp,
+                            modifier = Modifier.height(14.dp)
+                        )
+                    }
+                }
+
+                Column {
+                    Box(
+                        modifier = Modifier
+                            .horizontalScroll(scrollState)
+                            .width(heatmapWidth.dp)
+                            .padding(bottom = 4.dp)
+                    ) {
+                        for ((weekCol, monthName) in monthLabels) {
+                            Text(
+                                text = monthName,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = theme.textSecondary,
+                                fontSize = 9.sp,
+                                modifier = Modifier.offset(x = (weekCol * 16).dp)
+                            )
+                        }
+                    }
+
+                    Row(
+                        modifier = Modifier.horizontalScroll(scrollState),
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        val weeks = heatmapData.chunked(7)
+                        for (week in weeks) {
+                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                for (day in week) {
+                                    HeatmapCell(
+                                        day = day,
+                                        dividerColor = theme.divider
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeatmapCell(day: HeatmapDay, dividerColor: Color) {
+    var showTooltip by remember { mutableStateOf(false) }
+    val cellColor = heatmapColor(day.streakDays, day.isRelapse, dividerColor)
+
+    Box {
+        Box(
+            modifier = Modifier
+                .size(14.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(cellColor)
+                .then(
+                    if (day.isRelapse) {
+                        Modifier.background(cellColor, RoundedCornerShape(2.dp))
+                    } else {
+                        Modifier
+                    }
+                )
+                .clickable { showTooltip = !showTooltip }
+        )
+
+        if (showTooltip) {
+            Popup(
+                alignment = Alignment.TopCenter,
+                offset = androidx.compose.ui.unit.IntOffset(0, -40),
+                onDismissRequest = { showTooltip = false },
+                properties = PopupProperties(focusable = true)
+            ) {
+                LaunchedEffect(Unit) {
+                    kotlinx.coroutines.delay(2000)
+                    showTooltip = false
+                }
+                Surface(
+                    shape = RoundedCornerShape(6.dp),
+                    color = Color(0xFF333333),
+                    shadowElevation = 4.dp
+                ) {
+                    Column(
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = day.date.toString(),
+                            color = Color.White,
+                            fontSize = 10.sp
+                        )
+                        if (day.isRelapse) {
+                            Text(
+                                text = "Relapse",
+                                color = HeatmapRelapseBorder,
+                                fontSize = 10.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        } else {
+                            Text(
+                                text = "${day.streakDays} day streak",
+                                color = Color.White,
+                                fontSize = 10.sp
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Surface(
+    shape: RoundedCornerShape,
+    color: Color,
+    shadowElevation: androidx.compose.ui.unit.Dp,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .clip(shape)
+            .background(color)
+            .padding(shadowElevation)
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun HeatmapLegend() {
+    val theme = LocalTheme.current
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Text(
+            text = "Less",
+            style = MaterialTheme.typography.labelSmall,
+            color = theme.textSecondary,
+            fontSize = 9.sp
+        )
+        for (color in listOf(
+            theme.divider,
+            HeatmapGreen1,
+            HeatmapGreen2,
+            HeatmapGreen3,
+            HeatmapGreen5
+        )) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(color)
+            )
+        }
+        Text(
+            text = "More",
+            style = MaterialTheme.typography.labelSmall,
+            color = theme.textSecondary,
+            fontSize = 9.sp
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(HeatmapRelapse)
+        )
+        Text(
+            text = "Relapse",
+            style = MaterialTheme.typography.labelSmall,
+            color = theme.textSecondary,
+            fontSize = 9.sp
+        )
+    }
+}
+
+@Composable
+private fun DateFilterChips(
+    selectedFilter: DateFilter,
+    onFilterSelected: (DateFilter) -> Unit
+) {
+    val theme = LocalTheme.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        for (filter in DateFilter.entries) {
+            FilterChip(
+                selected = selectedFilter == filter,
+                onClick = { onFilterSelected(filter) },
+                label = {
+                    Text(
+                        text = filter.label,
+                        color = if (selectedFilter == filter) theme.textPrimary
+                        else theme.textSecondary
+                    )
+                },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = theme.buttonPrimary,
+                    containerColor = theme.cardContainer,
+                    selectedLabelColor = theme.textPrimary,
+                ),
+                border = FilterChipDefaults.filterChipBorder(
+                    borderColor = theme.divider,
+                    selectedBorderColor = theme.buttonPrimary,
+                    enabled = true,
+                    selected = selectedFilter == filter
+                )
+            )
+        }
+    }
+}
+
 @Composable
 private fun RelapseChart(
     modifier: Modifier = Modifier,
@@ -213,7 +559,7 @@ private fun RelapseChart(
                         textStyle = MaterialTheme.typography.bodySmall.copy(color = theme.textPrimary),
                     ),
                     labelProperties = LabelProperties(
-                        enabled = true,
+                        enabled = false,
                         textStyle = MaterialTheme.typography.labelSmall.copy(color = theme.textPrimary),
                         labels = chartData.map { it.date },
                     ),
@@ -307,6 +653,7 @@ private fun StreakSummaryCard(streakData: List<StreakData>) {
     }
 }
 
+@OptIn(ExperimentalTime::class)
 @Preview
 @Composable
 private fun AnalyticsScreenPreview() {
@@ -319,16 +666,33 @@ private fun AnalyticsScreenPreview() {
         streakData.map {
             ChartDataPoint(
                 y = it.streakDays.toFloat(),
-                date = it.relapseDate
+                date = it.relapseDate.formatDate(dateFormat2)
             )
         }
+    }
+    val heatmapData = remember {
+        val today =
+            kotlin.time.Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+        val startDate = today.minus(DatePeriod(days = 364))
+        val days = mutableListOf<HeatmapDay>()
+        var streak = 0
+        var date = startDate
+        while (date <= today) {
+            val isRelapse = date.dayOfMonth == 15 && date.monthNumber % 3 == 0
+            if (isRelapse) streak = 0
+            days.add(HeatmapDay(date, streak, isRelapse))
+            if (!isRelapse) streak++
+            date = date.plus(DatePeriod(days = 1))
+        }
+        days
     }
     MaterialTheme {
         AnalyticsScreen(
             uiState = AnalyticsState(
                 isLoading = false,
                 chartData = chartData,
-                streakData = streakData
+                streakData = streakData,
+                heatmapData = heatmapData
             )
         )
     }

--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/analytics/AnalyticsState.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/analytics/AnalyticsState.kt
@@ -1,12 +1,15 @@
 package dev.notsatria.stop_pmo.ui.screen.analytics
 
 import dev.notsatria.stop_pmo.domain.model.RelapseEvent
+import kotlinx.datetime.LocalDate
 
 data class AnalyticsState(
     val relapseEvents: List<RelapseEvent> = emptyList(),
     val isLoading: Boolean = true,
     val chartData: List<ChartDataPoint> = emptyList(),
-    val streakData: List<StreakData> = emptyList()
+    val streakData: List<StreakData> = emptyList(),
+    val heatmapData: List<HeatmapDay> = emptyList(),
+    val selectedFilter: DateFilter = DateFilter.ALL,
 )
 
 data class ChartDataPoint(
@@ -18,3 +21,17 @@ data class StreakData(
     val relapseDate: String,
     val streakDays: Int,
 )
+
+data class HeatmapDay(
+    val date: LocalDate,
+    val streakDays: Int,
+    val isRelapse: Boolean,
+)
+
+enum class DateFilter(val label: String, val days: Int?) {
+    DAYS_30("30d", 30),
+    DAYS_90("90d", 90),
+    MONTHS_6("6m", 180),
+    YEAR_1("1y", 365),
+    ALL("All", null);
+}

--- a/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/ui/screen/analytics/AnalyticsViewModel.kt
@@ -5,11 +5,23 @@ import androidx.lifecycle.viewModelScope
 import dev.notsatria.stop_pmo.domain.model.RelapseEvent
 import dev.notsatria.stop_pmo.domain.repository.RelapseRepository
 import dev.notsatria.stop_pmo.utils.calculateCurrentStreak
+import dev.notsatria.stop_pmo.utils.dateFormat2
+import dev.notsatria.stop_pmo.utils.formatDate
 import dev.notsatria.stop_pmo.utils.formatDateOnly
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
 
 class AnalyticsViewModel(
     private val repository: RelapseRepository
@@ -25,18 +37,40 @@ class AnalyticsViewModel(
     private fun loadAnalyticsData() {
         viewModelScope.launch {
             repository.allRelapseFlow().collect { relapseEvents ->
+                _uiState.update { it.copy(isLoading = true) }
                 val streakData = calculateStreakData(relapseEvents)
-                val chartData = processChartData(streakData)
+                val selectedFilter = _uiState.value.selectedFilter
+                val chartData = withContext(Dispatchers.Default) {
+                    processChartData(
+                        streakData,
+                        selectedFilter
+                    )
+                }
+                val heatmapData =
+                    withContext(Dispatchers.Default) { processHeatmapData(relapseEvents) }
 
                 _uiState.update {
                     it.copy(
                         relapseEvents = relapseEvents,
                         streakData = streakData,
                         chartData = chartData,
+                        heatmapData = heatmapData,
                         isLoading = false
                     )
                 }
             }
+        }
+    }
+
+    fun onFilterSelected(filter: DateFilter) {
+        val streakData = _uiState.value.streakData
+        val chartData = processChartData(streakData, filter)
+
+        _uiState.update {
+            it.copy(
+                selectedFilter = filter,
+                chartData = chartData
+            )
         }
     }
 
@@ -68,12 +102,75 @@ class AnalyticsViewModel(
         return streakList
     }
 
-    private fun processChartData(streakData: List<StreakData>): List<ChartDataPoint> {
-        return streakData.map { streak ->
+    @OptIn(ExperimentalTime::class)
+    private fun processChartData(
+        streakData: List<StreakData>,
+        filter: DateFilter
+    ): List<ChartDataPoint> {
+        val filtered = if (filter.days != null) {
+            val today = kotlin.time.Clock.System.now()
+                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val cutoff = today.minus(DatePeriod(days = filter.days))
+            streakData.filter { streak ->
+                try {
+                    val relapseDate = kotlinx.datetime.Instant.parse(streak.relapseDate)
+                        .toLocalDateTime(TimeZone.currentSystemDefault()).date
+                    relapseDate >= cutoff
+                } catch (_: Exception) {
+                    true
+                }
+            }
+        } else {
+            streakData
+        }
+
+        return filtered.map { streak ->
             ChartDataPoint(
                 y = streak.streakDays.toFloat(),
-                date = streak.relapseDate.formatDateOnly()
+                date = streak.relapseDate.formatDate(dateFormat2)
             )
         }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun processHeatmapData(events: List<RelapseEvent>): List<HeatmapDay> {
+        val today = kotlin.time.Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date
+        val startDate = today.minus(DatePeriod(days = 364))
+
+        val relapseDates = mutableSetOf<LocalDate>()
+        for (event in events) {
+            try {
+                val date = kotlinx.datetime.Instant.parse(event.occurredAt)
+                    .toLocalDateTime(TimeZone.currentSystemDefault()).date
+                relapseDates.add(date)
+            } catch (_: Exception) {
+                // Skip invalid dates
+            }
+        }
+
+        val heatmapDays = mutableListOf<HeatmapDay>()
+        var currentStreak = 0
+        var date = startDate
+
+        while (date <= today) {
+            val isRelapse = date in relapseDates
+            if (isRelapse) {
+                currentStreak = 0
+            }
+            heatmapDays.add(
+                HeatmapDay(
+                    date = date,
+                    streakDays = currentStreak,
+                    isRelapse = isRelapse
+                )
+            )
+            if (!isRelapse) {
+                currentStreak++
+            }
+            date = date.plus(DatePeriod(days = 1))
+        }
+
+        return heatmapDays
     }
 }

--- a/app/src/main/java/dev/notsatria/stop_pmo/utils/DateUtils.kt
+++ b/app/src/main/java/dev/notsatria/stop_pmo/utils/DateUtils.kt
@@ -54,6 +54,7 @@ fun String.toDayAgo(): String {
 
 val defaultDateFormat = SimpleDateFormat("dd MMM yyyy", Locale.ENGLISH)
 val dateFormat1 = SimpleDateFormat("dd MMM", Locale.ENGLISH)
+val dateFormat2 = SimpleDateFormat("dd/MM", Locale.ENGLISH)
 val timeFormat24H = SimpleDateFormat("HH:mm", Locale.ENGLISH)
 val timeFormat12H = SimpleDateFormat("hh:mm a", Locale.ENGLISH)
 
@@ -82,6 +83,17 @@ fun String.formatDateOnly(): String {
         val instant = Instant.parse(this)
         val date = Date(instant.toEpochMilliseconds())
         return dateFormat1.format(date)
+    } catch (_: Exception) {
+        return this
+    }
+}
+
+@OptIn(ExperimentalTime::class)
+fun String.formatDate(format: SimpleDateFormat): String {
+    try {
+        val instant = Instant.parse(this)
+        val date = Date(instant.toEpochMilliseconds())
+        return format.format(date)
     } catch (_: Exception) {
         return this
     }

--- a/docs/superpowers/specs/2026-05-02-heatmap-design.md
+++ b/docs/superpowers/specs/2026-05-02-heatmap-design.md
@@ -1,0 +1,176 @@
+# Analytics Heatmap Design
+
+**Date:** 2026-05-02
+**Feature:** GitHub-like activity heatmap + date filter for the Analytics screen
+
+## Overview
+
+Enhance the Analytics screen with a visual heatmap showing daily streak progress over the past 12 months, and add date filter presets (30d / 90d / 6m / 1y / All) to the existing line chart.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Heatmap data model | Hybrid: clean days + relapse markers | Best visual story — shows both progress and setbacks |
+| Time range | Rolling 12 months | Always current, like GitHub's contribution graph |
+| Layout | StreakSummary → Heatmap → Filter → Line Chart | Most useful info first |
+| Cell interaction | Tooltip on tap showing date and streak count | Adds detail without cluttering the default view |
+| Date filter | Preset chips (30d / 90d / 6m / 1y / All) | Quick access, no complex date picker needed |
+| Rendering approach | Row + Column composables | Simple, composable, 364 cells is trivial for Compose |
+| Filtering approach | In-memory in ViewModel | Small data set, no DAO changes needed |
+
+## Data Model
+
+### New data classes
+
+```kotlin
+data class HeatmapDay(
+    val date: kotlinx.datetime.LocalDate,
+    val streakDays: Int,      // 0 if relapse day or no data
+    val isRelapse: Boolean,
+)
+
+enum class DateFilter(val label: String, val days: Int?) {
+    DAYS_30("30d", 30),
+    DAYS_90("90d", 90),
+    MONTHS_6("6m", 180),
+    YEAR_1("1y", 365),
+    ALL("All", null);
+}
+```
+
+### Updated AnalyticsState
+
+```kotlin
+data class AnalyticsState(
+    val relapseEvents: List<RelapseEvent> = emptyList(),
+    val isLoading: Boolean = true,
+    val chartData: List<ChartDataPoint> = emptyList(),
+    val streakData: List<StreakData> = emptyList(),
+    val heatmapData: List<HeatmapDay> = emptyList(),
+    val selectedFilter: DateFilter = DateFilter.ALL,
+)
+```
+
+No Room schema changes. `RelapseEvent.occurredAt` (ISO 8601 string) is parsed to `LocalDate` for heatmap processing.
+
+## ViewModel Changes
+
+### New function: `processHeatmapData()`
+
+- Takes the full list of `RelapseEvent`s
+- Date range: today minus 12 months → today (52-53 weeks)
+- Builds a `List<HeatmapDay>` with one entry per day
+- For each day: checks if a relapse occurred → `isRelapse = true`
+- For streak days: calculates days since last relapse → `streakDays`
+- Days before the first relapse get `streakDays = 0`
+
+### New function: `onFilterSelected(filter: DateFilter)`
+
+- Updates `selectedFilter` in state
+- Reprocesses chart data only (heatmap unaffected)
+
+### Updated `processChartData()`
+
+- Filters events by the selected date range before mapping to `ChartDataPoint`
+- Filter logic: compute cutoff date = now minus `filter.days`, keep events after cutoff
+
+### Data flow
+
+```
+allRelapseFlow emits
+  → calculateStreakData()           → streakData (always all)
+  → processHeatmapData()            → heatmapData (always 12 months)
+  → processChartData(selectedFilter) → chartData (filtered)
+```
+
+## UI Components
+
+### 1. HeatmapCard
+
+A `Card` (matching existing card style: border + cardContainer background) containing:
+
+```
+Column
+├── Row: "Activity" title + color legend
+├── Month labels row ("Jan", "Feb", ... aligned to first week)
+└── LazyRow (horizontal scroll)
+    └── Row
+        ├── Column: day labels (Mon, Wed, Fri on alternating rows)
+        └── For each week (~52 columns):
+            └── Column (7 cells, one per day)
+                └── Box (14dp × 14dp, 2dp gap)
+                    ├── Background color based on streakDays
+                    └── If isRelapse: red bg + light red border
+```
+
+### 2. Heatmap Color Scale
+
+| Streak Days | Color | Hex |
+|---|---|---|
+| 0 (no data / reset) | Light gray | `theme.divider` |
+| 1-7 | Lightest green | `#bbf7d0` |
+| 8-14 | Light green | `#86efac` |
+| 15-30 | Medium green | `#4ade80` |
+| 31-60 | Dark green | `#22c55e` |
+| 60+ | Darkest green | `#166534` |
+| Relapse day | Red | `#dc2626` bg + `#fca5a5` border |
+
+### 3. Heatmap Tooltip
+
+- Material 3 `Popup` or `DropdownMenu` anchored to tapped cell
+- Content: formatted date, streak count, "Relapse" label if applicable
+- Auto-dismisses after 2 seconds or on tap outside
+
+### 4. DateFilterChips
+
+```
+Row (horizontalArrangement = spacedBy(8.dp), horizontalScroll)
+├── FilterChip("30d", selected, onClick)
+├── FilterChip("90d", selected, onClick)
+├── FilterChip("6m", selected, onClick)
+├── FilterChip("1y", selected, onClick)
+└── FilterChip("All", selected, onClick)
+```
+
+- Material 3 `FilterChip`
+- Selected: `theme.buttonPrimary` container, `theme.textPrimary` text
+- Unselected: `theme.cardContainer` container, `theme.divider` border, `theme.textSecondary` text
+- Default selection: `ALL`
+
+### 5. Layout
+
+```
+Scaffold(topBar = CenterTopBar("Analytics"))
+└── Column(fillMaxSize, padding 16dp)
+    ├── if loading → LoadingIndicator()
+    ├── if empty → EmptyStateMessage()
+    └── else → Column(verticalArrangement = spacedBy(16dp))
+        ├── StreakSummaryCard(streakData)            ← existing
+        ├── HeatmapCard(heatmapData)                 ← new
+        ├── DateFilterChips(selectedFilter, onSelect) ← new
+        └── RelapseChart(chartData)                  ← existing, filtered
+```
+
+### 6. Interaction Rules
+
+- `StreakSummaryCard` — shows stats from ALL relapses, unaffected by date filter
+- `HeatmapCard` — always shows rolling 12 months, unaffected by date filter
+- `DateFilterChips` — controls `RelapseChart` data only
+- `RelapseChart` — data filtered by selected preset before rendering
+- Loading state covers everything; empty state shows only if zero relapse events
+
+## Files to Modify
+
+| File | Changes |
+|---|---|
+| `AnalyticsState.kt` | Add `HeatmapDay`, `DateFilter`, update `AnalyticsState` |
+| `AnalyticsViewModel.kt` | Add `processHeatmapData()`, `onFilterSelected()`, update `processChartData()` |
+| `AnalyticsScreen.kt` | Add `HeatmapCard`, `DateFilterChips`, update layout |
+
+## Files Unchanged
+
+- `RelapseDao.kt` — no new queries
+- `RelapseRepository.kt` / `RelapseRepositoryImpl.kt` — no changes
+- `RelapseEventEntity.kt` / `RelapseEvent.kt` — no schema changes
+- `AppDatabase.kt` — no migration needed


### PR DESCRIPTION
   ## Summary
  - Add a GitHub-like 12-month rolling activity heatmap to the Analytics screen
    showing streak progress (green gradient) and relapse markers (red cells)
  - Add date filter chips (30d / 90d / 6m / 1y / All) to control the line chart
  - Heatmap cells show tooltips on tap with date and streak count
  - Month labels scroll in sync with the heatmap grid

  ## Test plan
  - [ ] Open Analytics screen and verify heatmap renders with 365 days of cells
  - [ ] Scroll heatmap horizontally — month labels should scroll in sync
  - [ ] Tap a heatmap cell — tooltip should show date and streak count
  - [ ] Tap a relapse cell — tooltip should show "Relapse" in red
  - [ ] Tap each date filter chip — line chart should update to show filtered data
  - [ ] Verify heatmap always shows 12 months regardless of filter selection
  - [ ] Check dark theme — heatmap colors should remain visible